### PR TITLE
Adding category = none to debug parts

### DIFF
--- a/Tree/debugPatch.cfg
+++ b/Tree/debugPatch.cfg
@@ -16,3 +16,11 @@
 @PART[*]:HAS[#TechRequired[debug]]:FINAL { 
 	%category = none
 }
+
+@TechTree:FINAL
+{
+	@RDNode:HAS[#id[debug]]
+	{
+		@cost = 1
+	}
+}

--- a/Tree/debugPatch.cfg
+++ b/Tree/debugPatch.cfg
@@ -10,5 +10,9 @@
 }
 
 @PART[*]:FINAL { 
-	@description = #$description$ <color=#7F7F7F> [$name$]</color> 
+	@description = #$description$ <color=#7F7F7F>[$name$]</color> 
+}
+
+@PART[*]:HAS[#TechRequired[debug]]:FINAL { 
+	%category = none
 }


### PR DESCRIPTION
For other patches that move parts with category = none to specific category nodes in VAB to be found at least.