### PR TITLE
Mod Support: Procedural Parts, Procedural Fairings

### DIFF
--- a/ModSupport/ProceduralFairings/ProceduralFairings.cfg
+++ b/ModSupport/ProceduralFairings/ProceduralFairings.cfg
@@ -40,100 +40,24 @@
 /////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
 
 //Tier 1 aerodynamics1
-@PART[KzResizableFairingBase]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics1
-}
-@PART[KzProcFairingSide1]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics1
-}
 
 //Tier 2 aerodynamics2
-@PART[KzResizableFairingBaseRing]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[RSBRibbedBase]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[RSBRibbedBase_Interstage]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[RSBTrussBase]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[RSBTrussBase_Interstage]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[SSTUBase]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[SSTUBase_Interstage]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[SSTUHollowRing]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PART[SSTUHollowRing_Interstage]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
-@PARTUPGRADE[FairingBaseMin0_4m]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics2
-}
 
 //Tier 3 aerodynamics3
 
 //Tier 4 aerodynamics4
 
 //Tier 5 aerodynamics5
-@PART[KzThrustPlate]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics5
-}
-@PARTUPGRADE[FairingBaseMax2_75m]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics5
-}
 
 //Tier 6 aerodynamics6
 
 //Tier 7 aerodynamics7
-@PARTUPGRADE[FairingBaseMax4m]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics7
-}
 
 //Tier 8 aerodynamics8
 
 //Tier 9 aerodynamics9
-@PARTUPGRADE[FairingBaseMax12m]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics9
-}
-@PARTUPGRADE[ThrustPlateMax12m]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics9
-}
 
 //Tier 10 aerodynamics10
-@PARTUPGRADE[FairingBaseMaxUnlimited]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics10
-}
-@PARTUPGRADE[ThrustPlateMaxUnlimited]:AFTER[ProceduralFairings]
-{
-    @TechRequired = aerodynamics10
-}
 
 //Tier 11 aerodynamics11
 
@@ -591,8 +515,56 @@
 //////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
 
 //Tier 1 construction1
+@PART[KzResizableFairingBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction1
+}
+@PART[KzProcFairingSide1]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction1
+}
 
 //Tier 2 construction2
+@PART[KzResizableFairingBaseRing]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[RSBRibbedBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[RSBRibbedBase_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[RSBTrussBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[RSBTrussBase_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[SSTUBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[SSTUBase_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[SSTUHollowRing]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PART[SSTUHollowRing_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
+@PARTUPGRADE[FairingBaseMin0_4m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction2
+}
 
 //Tier 3 construction3
 
@@ -600,15 +572,44 @@
 
 //Tier 5 construction5
 
+@PART[KzThrustPlate]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction5
+}
+@PARTUPGRADE[FairingBaseMax2_75m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction5
+}
+
 //Tier 6 construction6
 
 //Tier 7 construction7
+@PARTUPGRADE[FairingBaseMax4m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction7
+}
 
 //Tier 8 construction8
 
 //Tier 9 construction9
+@PARTUPGRADE[FairingBaseMax12m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction9
+}
+@PARTUPGRADE[ThrustPlateMax12m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction9
+}
 
 //Tier 10 construction10
+@PARTUPGRADE[FairingBaseMaxUnlimited]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction10
+}
+@PARTUPGRADE[ThrustPlateMaxUnlimited]:AFTER[ProceduralFairings]
+{
+    @TechRequired = construction10
+}
 
 //Tier 11 construction11
 

--- a/ModSupport/ProceduralFairings/ProceduralFairings.cfg
+++ b/ModSupport/ProceduralFairings/ProceduralFairings.cfg
@@ -1,0 +1,706 @@
+//Tiers
+// Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+// Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+// Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+// Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+// Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+// Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+// Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+// Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+// Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+// Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+// Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+// Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+@PART[KzResizableFairingBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics1
+}
+@PART[KzProcFairingSide1]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics1
+}
+
+//Tier 2 aerodynamics2
+@PART[KzResizableFairingBaseRing]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[RSBRibbedBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[RSBRibbedBase_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[RSBTrussBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[RSBTrussBase_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[SSTUBase]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[SSTUBase_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[SSTUHollowRing]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PART[SSTUHollowRing_Interstage]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+@PARTUPGRADE[FairingBaseMin0_4m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics2
+}
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+@PART[KzThrustPlate]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics5
+}
+@PARTUPGRADE[FairingBaseMax2_75m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics5
+}
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+@PARTUPGRADE[FairingBaseMax4m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics7
+}
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+@PARTUPGRADE[FairingBaseMax12m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics9
+}
+@PARTUPGRADE[ThrustPlateMax12m]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics9
+}
+
+//Tier 10 aerodynamics10
+@PARTUPGRADE[FairingBaseMaxUnlimited]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics10
+}
+@PARTUPGRADE[ThrustPlateMaxUnlimited]:AFTER[ProceduralFairings]
+{
+    @TechRequired = aerodynamics10
+}
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+
+//Tier 2 construction2
+
+//Tier 3 construction3
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+
+//Tier 6 construction6
+
+//Tier 7 construction7
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+
+//Tier 7 logistics7
+
+//Tier 8 logistics8
+
+//Tier 9 logistics9
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12

--- a/ModSupport/ProceduralParts/proceduralParts.cfg
+++ b/ModSupport/ProceduralParts/proceduralParts.cfg
@@ -747,7 +747,7 @@
 }
 
 //Tier 7 construction7
-PARTUPGRADE[ProceduralPartsDecouplerUnlimited]:AFTER[ProceduralParts]
+@PARTUPGRADE[ProceduralPartsDecouplerUnlimited]:AFTER[ProceduralParts]
 {
 	@techRequired = construction7
 }

--- a/ModSupport/ProceduralParts/proceduralParts.cfg
+++ b/ModSupport/ProceduralParts/proceduralParts.cfg
@@ -1,0 +1,866 @@
+//Tiers
+// Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+// Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+// Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+// Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+// Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+// Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+// Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+// Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+// Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+// Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+// Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+// Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+// Tier 0
+@PART[*]:HAS[@MODULE[ProceduralShapeCylinder]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeCylinder]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapeCone]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeCone]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapePill]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapePill]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapeBezierCone]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeBezierCone]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapePolygon]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapePolygon]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapeHollowCylinder]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeHollowCylinder]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapeHollowCone]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeHollowCone]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[ProceduralShapeHollowPill]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeHollowPill]
+	{
+		@techRequired = start
+	}
+}
+@PART[*]:HAS[@MODULE[DecouplerTweaker]]:AFTER[ProceduralParts]
+{
+	@MODULE[ProceduralShapeHollowPill]
+	{
+		@techRequired = start
+	}
+}
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 8 spaceplanes8
+
+//Tier 9 spaceplanes9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+@PARTUPGRADE[ProceduralPartsTankAviation]:AFTER[ProceduralParts]
+{
+	@techRequired = aerodynamics1
+}
+@PART[proceduralStructural]:AFTER[ProceduralParts]
+{
+	@techRequired = aerodynamics1
+}
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+@PART[proceduralHeatshield]:AFTER[ProceduralParts]
+{
+	@techRequired = landing4
+}
+@PARTUPGRADE[ProceduralPartsHeatshield0.125m]:AFTER[ProceduralParts]
+{
+	@techRequired = landing8
+}
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+@PARTUPGRADE[ProceduralPartsHeatshield3m]:AFTER[ProceduralParts]
+{
+	@techRequired = landing6
+}
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+@PARTUPGRADE[ProceduralPartsHeatshield5m]:AFTER[ProceduralParts]
+{
+	@techRequired = landing8
+}
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+@PARTUPGRADE[ProceduralPartsHeatshieldUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = landing10
+}
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+@PART[proceduralTankSRB]:AFTER[ProceduralParts]
+{
+	@techRequired = solids1
+}
+
+//Tier 2 solids2
+@PARTUPGRADE[ProceduralPartsSRB3m]:AFTER[ProceduralParts]
+{
+	@techRequired = solids2
+}
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+@PARTUPGRADE[ProceduralPartsSRB10kL]:AFTER[ProceduralParts]
+{
+	@techRequired = solids4
+}
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+@PARTUPGRADE[ProceduralPartsSRBDiam3m]:AFTER[ProceduralParts]
+{
+	@techRequired = solids6
+}
+
+//Tier 7 solids7
+@PARTUPGRADE[ProceduralPartsSRB40kL]:AFTER[ProceduralParts]
+{
+	@techRequired = solids7
+}
+//Tier 8 solids8
+@PARTUPGRADE[ProceduralPartsSRB50kL]:AFTER[ProceduralParts]
+{
+	@techRequired = solids8
+}
+
+//Tier 9 solids9
+@PARTUPGRADE[ProceduralPartsSRBUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = solids9
+}
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+@PART[proceduralTankLiquid]:AFTER[ProceduralParts]
+{
+	@TechRequired = kerolox1
+}
+//Tier 2 tanks2
+@PARTUPGRADE[ProceduralPartsTank1500L]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks2
+}
+@PARTUPGRADE[ProceduralPartsTank2500L]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks2
+}
+@PARTUPGRADE[ProceduralPartsTankMiniaturization]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks2
+}
+
+//Tier 3 tanks3
+
+
+//Tier 4 tanks4
+@PART[proceduralTankRCS]:AFTER[ProceduralParts]
+{
+	@TechRequired = tanks4
+}
+
+//Tier 5 tanks5
+@PARTUPGRADE[ProceduralPartsTank20000L]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks5
+}
+@PARTUPGRADE[ProceduralPartsTank37000L]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks5
+}
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+@PARTUPGRADE[ProceduralPartsTank45000L]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks7
+}
+@PARTUPGRADE[ProceduralPartsTank85000L]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks7
+}
+
+//Tier 8 tanks8
+@PARTUPGRADE[ProceduralPartsTankUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = tanks8
+}
+
+//Tier 9 tanks9
+
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+@PART[proceduralTankXenon]:AFTER[ProceduralParts]
+{
+	@TechRequired = ion7
+}
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+@PART[proceduralBattery]:AFTER[ProceduralParts]
+{
+	@techRequired = electrics4
+}
+
+//Tier 5 electrics5
+@PARTUPGRADE[ProceduralPartsBattery300]:AFTER[ProceduralParts]
+{
+	@techRequired = electrics5
+}
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+@PARTUPGRADE[ProceduralPartsBattery600]:AFTER[ProceduralParts]
+{
+	@techRequired = electrics7
+}
+
+//Tier 8 electrics8
+@PARTUPGRADE[ProceduralPartsBattery2400]:AFTER[ProceduralParts]
+{
+	@techRequired = electrics8
+}
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+@PARTUPGRADE[ProceduralPartsBattery4800]:AFTER[ProceduralParts]
+{
+	@techRequired = electrics10
+}
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+@PARTUPGRADE[ProceduralPartsBatteryUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = electrics12
+}
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+@PART[proceduralNoseCone]:AFTER[ProceduralParts]
+{
+	@techRequired = construction1
+}
+
+@PART[proceduralStackDecoupler]:AFTER[ProceduralParts]
+{
+	@techRequired = construction1
+}
+
+//Tier 2 construction2
+@PARTUPGRADE[ProceduralPartsNoseCone1.5M]:AFTER[ProceduralParts]
+{
+	@techRequired = construction2
+}
+@PARTUPGRADE[ProceduralPartsDecoupler0.125m]:AFTER[ProceduralParts]
+{
+	@techRequired = construction2
+}
+
+//Tier 3 construction3
+@PARTUPGRADE[ProceduralPartsNoseCone2.5M]:AFTER[ProceduralParts]
+{
+	@techRequired = construction3
+}
+@PARTUPGRADE[ProceduralPartsDecoupler3m]:AFTER[ProceduralParts]
+{
+	@techRequired = construction3
+}
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+@PARTUPGRADE[ProceduralPartsDecoupler4.5m]:AFTER[ProceduralParts]
+{
+	@techRequired = construction5
+}
+
+//Tier 6 construction6
+@PARTUPGRADE[ProceduralPartsNoseConeUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = construction6
+}
+
+//Tier 7 construction7
+PARTUPGRADE[ProceduralPartsDecouplerUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = construction7
+}
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+
+//Tier 7 logistics7
+
+//Tier 8 logistics8
+
+//Tier 9 logistics9
+@PART[proceduralTankOre]:AFTER[ProceduralParts]
+{
+	@techRequired = logistics9
+}
+@PARTUPGRADE[ProceduralPartsTankOre1]:AFTER[ProceduralParts]
+{
+	@techRequired = logistics9
+}
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+@PARTUPGRADE[ProceduralPartsTankUnlimited]:AFTER[ProceduralParts]
+{
+	@techRequired = logistics11
+}
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12


### PR DESCRIPTION
Initial Procedural Parts support.

I followed the Squad patches for parts and part upgrades. When the Squad patches reached or exceeded a part upgrade, it was placed in that node.