### PR TITLE
Mod Support: ModularLaunchPads

### DIFF
--- a/ModSupport/ModularLaunchPads/ModularLaunchPads.cfg
+++ b/ModSupport/ModularLaunchPads/ModularLaunchPads.cfg
@@ -1,0 +1,1203 @@
+// ModularLaunchPads are distributed along the "Construction" branch of
+// the tech tree in SkyhawkScienceSystem, and the custom nodes introduced
+// by ModularLaunchPads are not needed.
+@TechTree:AFTER[ModularLaunchPads] {
+    -RDNode:HAS[#id[launchStands]] {}
+    -RDNode:HAS[#id[launchPlates]] {}
+    -RDNode:HAS[#id[generalLaunchPad]] {}
+    -RDNode:HAS[#id[soyuzLaunchBase]] {}
+    -RDNode:HAS[#id[saturnLaunchPad]] {}
+    -RDNode:HAS[#id[shuttleLaunchPad]] {}
+}
+
+//Tiers
+//Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+//Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+//Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+//Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+//Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+//Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+//Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+//Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+//Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+//Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+//Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+//Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+//Tier 0 start
+@PART[AM_MLP_MilkstoolLaunchStand1]:AFTER[ModularLaunchPads] {
+    TechRequired = start
+}
+@PART[AM_MLP_LaunchRailMini]:AFTER[ModularLaunchPads] {
+    TechRequired = start
+}
+@PART[AM_MLP_TestStandSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = start
+}
+@PART[AM_MLP_TestStandEngine]:AFTER[ModularLaunchPads] {
+    TechRequired = start
+}
+@PART[AM_MLP_TestStandTower]:AFTER[ModularLaunchPads] {
+    TechRequired = start
+}
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+@PART[AM_MLP_MilkstoolLaunchStand2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_GeneralUmbilicalDroopA]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchStandSmallUmbilical]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchRailLarge]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchRailMedium]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchRailSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchStandServiceTower1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchStandServiceTower2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_LaunchStandServiceTower3]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_SmallLaunchStandRect]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_SmallLaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_SmallTowerSwingArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_SmallTowerSwingArmMedium]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_SmallTowerSwingArmLarge]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_GeneralUmbilicalDroopA]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+@PART[AM_MLP_GeneralUmbilicalDroopB]:AFTER[ModularLaunchPads] {
+    TechRequired = construction1
+}
+
+//Tier 2 construction2
+@PART[AM_MLP_MilkstoolLaunchStand3]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_FlatLaunchBaseMini]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralFallbackUmbilicalTower]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold3]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold4]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold5]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold6]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralHold7]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralLaunchBaseSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralROFI]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralServiceTowerSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralServiceTowerSmallSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralServiceTowerSmallTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralStrongbackTowerMini]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralTowerSwingArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralTowerSwingArmMedium]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralTowerSwingArmLarge]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_GeneralUmbilicalDroopC]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_LaunchPlateRnd1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_LaunchPlateSqr1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_MilkstoolMini1S]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_MilkstoolMini1T]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_RedstoneLaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_LaunchStandSmallPole]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_VanguardLaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+@PART[AM_MLP_VanguardServiceTower]:AFTER[ModularLaunchPads] {
+    TechRequired = construction2
+}
+
+//Tier 3 construction3
+@PART[AM_MLP_FlatLaunchBaseSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralLaunchBaseMedium]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralServiceTowerMedium]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralServiceTowerMediumSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralServiceTowerMediumTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralStrongbackTowerSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralStrongbackTowerFull]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralUmbilicalDroopD]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_GeneralUmbilicalDrop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_LaunchPlateRnd2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_LaunchPlateSqr2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_JupiterPetalCover]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_MilkstoolMini2S]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_MilkstoolMini2T]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_ThorLaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+@PART[AM_MLP_ThorServiceTowerFallback]:AFTER[ModularLaunchPads] {
+    TechRequired = construction3
+}
+
+//Tier 4 construction4
+@PART[AM_MLP_GeneralLaunchPlate]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_GeneralLaunchBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_GeneralTowerMulti]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_GeneralServiceTowerLargeSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_GeneralServiceTowerLargeTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[MountPlatform_MLP]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_GeneralUmbilicalDroopE]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_GeneralUmbilicalDropLarge]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_LaunchPlateRnd3]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_LaunchPlateSqr3]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_MilkstoolMini3S]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_MilkstoolMini3M]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+@PART[AM_MLP_MilkstoolMini3T]:AFTER[ModularLaunchPads] {
+    TechRequired = construction4
+}
+
+//Tier 5 construction5
+@PART[AM_MLP_GeneralCrewElevatorMiniArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_GeneralCrewElevatorMiniArmS]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_GeneralCrewElevatorMini]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_GeneralCrewElevatorMiniSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_GeneralTowerDeltaII]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SpecialServiceTowerDeltaIIBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SpecialServiceTowerDeltaIISec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SpecialServiceTowerDeltaIISec2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SpecialServiceTowerDeltaIITop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_LaunchStandServiceTower4]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasLaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasSepClampArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasSepSideUmb]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasUmbilicalArmAgena]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasUmbilicalArmCentaur1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasUmbilicalArmCentaur2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_AtlasUmbilicalArmCentaur]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_CrewElevatorAtlasUmbilical]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_LaunchStandCrewElevatorAtlas]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_LaunchStandCrewElevatorMercury]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_LaunchStandCrewWalkwayMercury]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIILaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerMast]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerModBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerModSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerModSec2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerModTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerSingle]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerUmbilicalGem]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerUmbilical]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerUmbilicalGem2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_TitanIIServiceTowerUmbilical2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SoyuzLaunchBaseArmLG]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SoyuzLaunchBaseArmSM]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SoyuzLaunchBaseClampArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SoyuzLaunchBaseElevator]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SoyuzLaunchBaseGantry]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+@PART[AM_MLP_SoyuzLaunchBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction5
+}
+
+//Tier 6 construction6
+@PART[AM_MLP_GeneralCrewElevatorSmall]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_CrewElevatorSmallSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_CrewElevatorSmallTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_GeneralServiceTowerXLBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_GeneralServiceTowerXLSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_GeneralServiceTowerXLTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_LaunchStandCrewElevatorGemini]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_Titan3LaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+@PART[AM_MLP_TitanIIITowerMast]:AFTER[ModularLaunchPads] {
+    TechRequired = construction6
+}
+
+//Tier 7 construction7
+@PART[AM_MLP_GeneralCrewArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_GeneralCrewArmSmallMount]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_GeneralCrewElevator]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_CrewElevatorLargeExt]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_CrewElevatorLargeSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_CrewElevatorLargeTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_GeneralTowerAtlasV]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_SpecialServiceTowerAtlasVBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_SpecialServiceTowerAtlasVSec1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_SpecialServiceTowerAtlasVSec2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_SpecialServiceTowerAtlasVTop]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_SaturnLaunchStandPedestal]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_LargeLaunchStand]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+@PART[AM_MLP_HoldArmSaturnIB]:AFTER[ModularLaunchPads] {
+    TechRequired = construction7
+}
+
+//Tier 8 construction8
+@PART[AM_MLP_GeneralCrewElevator2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_CrewElevatorXLargeSec]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerRodanCrewArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_LaunchPlateN1]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_HoldArmSaturnV]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerCrewArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnHammerheadCrane]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnLauncherMilkstool]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnLauncherTSM]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnLightningMast]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnMilkstoolClamp]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnMobileLauncherClampBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerBaseSquare]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerMultiSection]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerCrewFloor]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerCrewSection]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerDamperArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArmGen]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm0]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArmBDB]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm2]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm3]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm4]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm5]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm6]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm7]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerSwingArm8]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnTowerTopSection]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleLauncherFSSBase]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerMultiSection]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerCrewFloor]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerCrewSection]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerTopSection]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleLauncherBaseClamp]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleLauncherRSSHinge]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleLauncherRSS]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleLauncherSRBHold]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleLauncherTSM]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_SaturnLightningMastAlt]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerArmHydrogen]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerArmIntertank]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerArmLOX]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerCrewArm]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+@PART[AM_MLP_ShuttleTowerIntertankStructure]:AFTER[ModularLaunchPads] {
+    TechRequired = construction8
+}
+
+//Tier 9 construction9
+@PART[AM_MLP_LaunchPlateEnergia]:AFTER[ModularLaunchPads] {
+    TechRequired = construction9
+}
+@PART[AM_MLP_LaunchPlateFalcon9]:AFTER[ModularLaunchPads] {
+    TechRequired = construction9
+}
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+
+//Tier 7 logistics7
+
+//Tier 8 logistics8
+
+//Tier 9 logistics9
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12
+
+


### PR DESCRIPTION
This integrates the Modular Launch Pads into the tree.

I have decided to drop the custom nodes MLP usually adds to the tree and instead distribute the parts over the construction branch at the appropriate tiers for the rockets they support. 

Most of the generic parts are in tiers 1-4, with a minimal set to get the first sounding rocket off the pad in tier 0. 

The themed pads inspired by real rockets are in the same tiers that the corresponding BDB rockets are in (with a best guess for the Soyuz pad), starting with the Vanguard launch stand in tier 2 and going up to the Saturn V and Space Shuttle pads in tier 8. Tier 9 finally adds the specialized launch plates for Falcon 9 and Energia, beyond tier 9 there are no more Modular Launch Pad parts.