### PR TITLE
ModSupport (kOS): Drop legacy part from tree.

### DIFF
--- a/ModSupport/kOS/kOS.cfg
+++ b/ModSupport/kOS/kOS.cfg
@@ -116,7 +116,7 @@ Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous p
 }
 @PART[kOSMachine0m]:AFTER[kOS] //
 {
-	@TechRequired = control1
+	@TechRequired = unresearchable
 
 }
 


### PR DESCRIPTION
The kOSMachine0m part is a legacy version of the KR-2042, no use to have both in the tech tree.