### PR TITLE
Support for MandatoryRCS: Don't apply the reaction wheel nerf if MandatoryRCS is installed

### DIFF
--- a/Patches/Control/ReactionWheelNerf.cfg
+++ b/Patches/Control/ReactionWheelNerf.cfg
@@ -1,5 +1,5 @@
 //Thanks to KerbalWitchery for the code inspiration, and Mandatory RCS for the overall idea!
-@PART[*]:HAS[@MODULE[ModuleReactionWheel],!MODULE[ModuleEngines*]:HAS[@PROPELLANT[IntakeAtm]]]:AFTER[zzzSkyhawkScienceSystem] {
+@PART[*]:HAS[@MODULE[ModuleReactionWheel],!MODULE[ModuleEngines*]:HAS[@PROPELLANT[IntakeAtm]]]:NEEDS[!MandatoryRCS]:AFTER[zzzSkyhawkScienceSystem] {
 	@MODULE[ModuleReactionWheel] {
 		@PitchTorque *= 0.01
 		@RollTorque *= 0.01


### PR DESCRIPTION
See https://forum.kerbalspaceprogram.com/index.php?/topic/204768-v100-the-skyhawk-science-system-a-new-bdb-focused-tech-tree/&do=findComment&comment=4069714