### PR TITLE
Procedural Parts Hypergolics Support

### DIFF
--- a/ModSupport/ProceduralFairings/ProceduralFairings.cfg
+++ b/ModSupport/ProceduralFairings/ProceduralFairings.cfg
@@ -519,7 +519,7 @@
 {
     @TechRequired = construction1
 }
-@PART[KzProcFairingSide1]:AFTER[ProceduralFairings]
+@PART[KzProcFairingSide*]:AFTER[ProceduralFairings]
 {
     @TechRequired = construction1
 }

--- a/ModSupport/ProceduralParts/ProceduralPartsHypergolic.cfg
+++ b/ModSupport/ProceduralParts/ProceduralPartsHypergolic.cfg
@@ -2,7 +2,7 @@
 {
 	@MODULE[TankContentSwitcher]
 	{
-		%TANK_TYPE_OPTION[SSS_Hypergolic]
+		%TANK_TYPE_OPTION[Hypergolic]
 		{
 			%dryDensity = 0.1089
 			%RESOURCE[Aerozine50]

--- a/ModSupport/ProceduralParts/ProceduralPartsHypergolic.cfg
+++ b/ModSupport/ProceduralParts/ProceduralPartsHypergolic.cfg
@@ -1,0 +1,18 @@
+@PART[procedural*Liquid]:FINAL
+{
+	@MODULE[TankContentSwitcher]
+	{
+		%TANK_TYPE_OPTION[SSS_Hypergolic]
+		{
+			%dryDensity = 0.1089
+			%RESOURCE[Aerozine50]
+			{
+				%unitsPerKL = 391.139189
+			}
+			%RESOURCE[NitrogenTetroxide]
+			{
+				%unitsPerKL = 478.059
+			}
+		}
+	}
+}

--- a/ModSupport/ProceduralParts/proceduralParts.cfg
+++ b/ModSupport/ProceduralParts/proceduralParts.cfg
@@ -114,7 +114,7 @@
 }
 @PART[proceduralStructural]:AFTER[ProceduralParts]
 {
-	@techRequired = aerodynamics1
+	@TechRequired = aerodynamics1
 }
 
 //Tier 2 aerodynamics2
@@ -241,7 +241,7 @@
 //Tier 4 landing4
 @PART[proceduralHeatshield]:AFTER[ProceduralParts]
 {
-	@techRequired = landing4
+	@TechRequired = landing4
 }
 @PARTUPGRADE[ProceduralPartsHeatshield0.125m]:AFTER[ProceduralParts]
 {
@@ -617,7 +617,7 @@
 //Tier 4 electrics4
 @PART[proceduralBattery]:AFTER[ProceduralParts]
 {
-	@techRequired = electrics4
+	@TechRequired = electrics4
 }
 
 //Tier 5 electrics5
@@ -704,12 +704,12 @@
 //Tier 1 construction1
 @PART[proceduralNoseCone]:AFTER[ProceduralParts]
 {
-	@techRequired = construction1
+	@TechRequired = construction1
 }
 
 @PART[proceduralStackDecoupler]:AFTER[ProceduralParts]
 {
-	@techRequired = construction1
+	@TechRequired = construction1
 }
 
 //Tier 2 construction2


### PR DESCRIPTION
Support for hypergolics in Procedural Parts fuel tanks. Hydrazine is already covered in the RCS tank without issues

