### PR TITLE
(MOAR) Station Science Support

### DIFF
--- a/ModSupport/StationScience/StationScience.cfg
+++ b/ModSupport/StationScience/StationScience.cfg
@@ -1,0 +1,134 @@
+/*
+TechRequired
+
+advExploration => science7
+ - StnSciLab
+ - StnSciExperiment1
+ - costlyExperimentPlantGrowth
+ - costlyExperimentRocketFuels
+
+largeElectrics => science8
+ - StnSciCyclo
+ - StnSciSpectro
+ - StnSciExperiment2
+ - StnSciExperiment3
+ - costlyExperimentProgradeKuarqs
+ - costlyExperimentRetrogradeKuarqs
+
+specializedElectrics => science8
+ - StnSciExperiment4
+ - costlyExperimentEccentricKuarqs
+ - costlyExperimentAdvancedFuels
+
+scienceTech => science9
+ - StnSciKib
+ - StnSciKibJr
+ - StnSciZoo
+ - StnSciExperiment5
+ - costlyExperimentCreatureComforts
+
+advScienceTech => science10
+ - StnSciExperiment6
+ - costlyExperimentKuarqBioactivity
+ - costlyExperimentPlasmaFuels
+ 
+Lab => Cyclo => Zoo
+*/
+
+
+// science 7
+// first station science with the first possible permanent station
+// i.e. LMSS
+@PART[StnSciLab]:AFTER[StationScience]
+{
+	@TechRequired = science7
+}
+@PART[StnSciExperiment1]:AFTER[StationScience]
+{
+	@TechRequired = science7
+}
+
+@PART[costlyExperimentPlantGrowth]:AFTER[StationScience]
+{
+	@TechRequired = science7
+}
+@PART[costlyExperimentRocketFuels]:AFTER[StationScience]
+{
+	@TechRequired = science7
+}
+
+// science 8
+@PART[StnSciCyclo]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[StnSciSpectro]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[StnSciExperiment2]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[StnSciExperiment3]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[StnSciExperiment4]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+
+@PART[costlyExperimentProgradeKuarqs]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[costlyExperimentRetrogradeKuarqs]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[costlyExperimentEccentricKuarqs]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+@PART[costlyExperimentAdvancedFuels]:AFTER[StationScience]
+{
+	@TechRequired = science8
+}
+
+// science 9
+@PART[StnSciKib]:AFTER[StationScience]
+{
+	@TechRequired = science9
+}
+@PART[StnSciKibJr]:AFTER[StationScience]
+{
+	@TechRequired = science9
+}
+@PART[StnSciZoo]:AFTER[StationScience]
+{
+	@TechRequired = science9
+}
+@PART[StnSciExperiment5]:AFTER[StationScience]
+{
+	@TechRequired = science9
+}
+@PART[costlyExperimentCreatureComforts]:AFTER[StationScience]
+{
+	@TechRequired = science9
+}
+
+// science 10
+@PART[StnSciExperiment6]:AFTER[StationScience]
+{
+	@TechRequired = science10
+}
+
+@PART[costlyExperimentKuarqBioactivity]:AFTER[StationScience]
+{
+	@TechRequired = science10
+}
+@PART[costlyExperimentPlasmaFuels]:AFTER[StationScience]
+{
+	@TechRequired = science10
+}


### PR DESCRIPTION
(MOAR) Station Science support.

~~I found that the "old" striped cylinder experiments were deprecated at some point, but I've included patches for them for posterity.~~
The new experiments are the "costly" ones.

The first experiment and lab are unlocked on the same tier as the LDSS in the science branch, and the rest are unlocked in the three or four nodes afterwards.

EDIT: The white-cylinder experiments still exist it seems:

![image](https://user-images.githubusercontent.com/12767476/148692403-3e52068f-0318-42cc-ae93-ae9cb9bb4fde.png)
