### PR TITLE
KipDockingPorts Support

### DIFF
--- a/ModSupport/KipEng/KipDockingPorts.cfg
+++ b/ModSupport/KipEng/KipDockingPorts.cfg
@@ -27,7 +27,7 @@ metaMaterials => spaceStations9 (universal == more advanced)
 {
 	@TechRequired = spaceStations9
 }
-@PART[kipunivdockport25AFTER[KipEng]
+@PART[kipunivdockport25]:AFTER[KipEng]
 {
 	@TechRequired = spaceStations9
 }

--- a/ModSupport/KipEng/KipDockingPorts.cfg
+++ b/ModSupport/KipEng/KipDockingPorts.cfg
@@ -1,0 +1,37 @@
+/* TechRequired
+
+advConstruction => spaceStations7 (crew transfer == MOL docking port)
+ - kipactiveport
+ - kippassiveport
+
+precisionEngineering => spaceStations9 (universal == more advanced)
+ - kipunivdockport125
+
+metaMaterials => spaceStations9 (universal == more advanced)
+ - kipunivdockport25
+ - kipunivdockport375
+*/
+
+// spaceStations7
+@PART[kipactiveport]:AFTER[KipEng]
+{
+	@TechRequired = spaceStations7
+}
+@PART[kippassiveport]:AFTER[KipEng]
+{
+	@TechRequired = spaceStations7
+}
+
+// spaceStations9
+@PART[kipunivdockport125]:AFTER[KipEng]
+{
+	@TechRequired = spaceStations9
+}
+@PART[kipunivdockport25AFTER[KipEng]
+{
+	@TechRequired = spaceStations9
+}
+@PART[kipunivdockport375]:AFTER[KipEng]
+{
+	@TechRequired = spaceStations9
+}


### PR DESCRIPTION
Support for the docking ports in [KipDockingPorts](https://forum.kerbalspaceprogram.com/index.php?/topic/194930-112x-kip-docking-ports-v10-2021-07-05/).

The 1.25m gendered ports are unlocked with the MOL ring-and-fork ports.

The universal ports are all unlocked at the same time after Apollo docking ports with Spacelab.

