### PR TITLE
ExtraDockingPorts support

### DIFF
--- a/ModSupport/ExtraDockingPorts/ExtraDockingPorts.cfg
+++ b/ModSupport/ExtraDockingPorts/ExtraDockingPorts.cfg
@@ -1,0 +1,29 @@
+/* ExtraDockingPorts TechRequired
+
+precisionEngineering => spaceStations6
+- ExtraDockingPorts-TinyModularDockingPort // 0.625
+- ExtraDockingPorts-TinyModularParachute
+
+composites => spaceStations7
+- ExtraDockingPorts-SmallCompactDockingPort // 1.25
+- ExtraDockingPorts-SmallModularDockingPort // 1.25
+- ExtraDockingPorts-SmallModularParachute
+
+composites => spaceStations8
+- ExtraDockingPorts-MediumDockingPort // 1.825
+*/
+
+@PART[ExtraDockingPorts-Tiny*]:AFTER[ExtraDockingPorts]
+{
+	@TechRequired = spaceStations6
+}
+
+@PART[ExtraDockingPorts-Small*]:AFTER[ExtraDockingPorts]
+{
+	@TechRequired = spaceStations7
+}
+
+@PART[ExtraDockingPorts-Medium*]:AFTER[ExtraDockingPorts]
+{
+	@TechRequired = spaceStations8
+}


### PR DESCRIPTION
ExtraDockingPorts adds in (currently) 4 stock-alike/Restock-alike docking ports.

The mod adds in two ports, in 0.625m and 1.25m sizes, that have 3 nodes for attaching parachutes, similar to the Apollo/Kane capsule-docking port adapter.
It also adds in a "compact" 1.25m port without the outer ring at the base.
Finally, it adds in a 1.825m stock-alike docking port.

I've placed each size with the stock ports of that size: 0.625m in stations 6, 1.25m in 7, and 1.835 in 8.

