### PR TITLE
Config for TAC LS parts

### DIFF
--- a/ModSupport/ThunderAerospace/Life Support Containers.cfg
+++ b/ModSupport/ThunderAerospace/Life Support Containers.cfg
@@ -1,0 +1,726 @@
+//Tiers
+Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+
+//Tier 2 construction2
+
+//Tier 3 construction3
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+
+//Tier 6 construction6
+
+//Tier 7 construction7
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+@PART[TacFoodContainerSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacLifeSupportContainerSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}@PART[TacOxygenContainerSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacWasteContainerSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacWaterContainerSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+
+//Tier 7 logistics7
+@PART[TacFoodContainer]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+@PART[TacLifeSupportContainer]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}@PART[TacOxygenContainer]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+@PART[TacWasteContainer]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+@PART[TacWaterContainer]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+
+//Tier 8 logistics8
+@PART[TacFoodContainerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[TacLifeSupportContainerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}@PART[TacOxygenContainerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[TacWasteContainerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[TacWaterContainerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+
+//Tier 9 logistics9
+@PART[TacFoodContainerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics9
+
+}
+@PART[TacLifeSupportContainerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics9
+
+}@PART[TacOxygenContainerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics9
+
+}
+@PART[TacWasteContainerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics9
+
+}
+@PART[TacWaterContainerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics9
+
+}
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12

--- a/ModSupport/ThunderAerospace/Life Support Hex Cans.cfg
+++ b/ModSupport/ThunderAerospace/Life Support Hex Cans.cfg
@@ -1,0 +1,702 @@
+//Tiers
+Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+
+//Tier 2 construction2
+
+//Tier 3 construction3
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+
+//Tier 6 construction6
+
+//Tier 7 construction7
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+@PART[HexCanOxygenSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[HexCanDrinkingWaterSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}@PART[HexCanFoodSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[HexCanLifeSupportSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[HexCanLifeSupportWasteSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+
+//Tier 7 logistics7
+@PART[HexCanOxygen]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+@PART[HexCanDrinkingWater]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}@PART[HexCanFood]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+@PART[HexCanLifeSupport]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+@PART[HexCanLifeSupportWaste]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+
+//Tier 8 logistics8
+@PART[HexCanOxygenLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[HexCanDrinkingWaterLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}@PART[HexCanFoodLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[HexCanLifeSupportLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[HexCanLifeSupportWasteLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+
+//Tier 9 logistics9
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12

--- a/ModSupport/ThunderAerospace/MFT.cfg
+++ b/ModSupport/ThunderAerospace/MFT.cfg
@@ -1,0 +1,650 @@
+//Tiers
+Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+
+//Tier 2 construction2
+
+//Tier 3 construction3
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+
+//Tier 6 construction6
+
+//Tier 7 construction7
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+@PART[TacLifeSupportMFTContainerSmall]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+
+//Tier 7 logistics7
+@PART[TacLifeSupportMFTContainer]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics7
+
+}
+
+//Tier 8 logistics8
+@PART[TacLifeSupportMFTContainerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+
+//Tier 9 logistics9
+@PART[TacLifeSupportMFTContainerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics9
+
+}
+
+//Tier 10 logistics10
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12

--- a/ModSupport/ThunderAerospace/Recyclers.cfg
+++ b/ModSupport/ThunderAerospace/Recyclers.cfg
@@ -1,0 +1,685 @@
+//Tiers
+Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1.25m parts
+Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1.5m parts
+Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1.875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2.5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3.125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3.75m parts - probes include Voyager and RoveMate gear
+Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+Tier 10 - Near Future Rocketry - Advanced "game changer" rockets - Starship/BFS, New Glenn, etc - 7.5m parts - near future probe missions like Europa Clipper
+Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+
+
+/////////////////////////
+/////Aviation Branch/////
+/////////////////////////
+
+/////Spaceplanes (Turbojets, Scramjets, Ramjets, MultiMode Engines, Atomic Jets, etc) (spaceplanes#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 spaceplanes4
+
+//Tier 5 spaceplanes5
+
+//Tier 6 spaceplanes6
+
+//Tier 7 spaceplanes7
+
+//Tier 9 spaceplanes9
+
+//Tier 11 spaceplanes11
+
+/////Aerodynamics (Most Fuselages and Fueltanks, general aviation parts, wings) (aerodynamics#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aerodynamics2
+
+//Tier 3 aerodynamics3
+
+//Tier 4 aerodynamics4
+
+//Tier 5 aerodynamics5
+
+//Tier 6 aerodynamics6
+
+//Tier 7 aerodynamics7
+
+//Tier 8 aerodynamics8
+
+//Tier 9 aerodynamics9
+
+//Tier 10 aerodynamics10
+
+//Tier 11 aerodynamics11
+
+/////Commercial Aerodynamics (Turbofan Engines, Passenger Modules, Plane Landing Gear, FAT-455 parts) (aviation#)
+
+//Tier 1 aerodynamics1
+
+//Tier 2 aviation2
+
+//Tier 3 aviation3
+
+//Tier 4 aviation4
+
+//Tier 5 aviation5
+
+//Tier 6 aviation6
+
+//Tier 7 aviation7
+
+
+////////////////////////
+/////Control Branch/////
+////////////////////////
+
+/////Communications (Antennae) (comms#)
+
+//Tier 1 control1
+
+//Tier 2 comms2
+
+//Tier 3 comms3
+
+//Tier 4 comms4
+
+//Tier 5 comms5
+
+//Tier 6 comms6
+
+//Tier 7 comms7
+
+//Tier 8 comms8
+
+//Tier 9 comms9
+
+//Tier 10 comms10
+
+//Tier 11 comms11
+
+/////Control (Reaction Wheels, RCS Thrusters, Drone Cores) (control#)
+
+//Tier 1 control1
+
+//Tier 2 control2
+
+//Tier 3 control3
+
+//Tier 4 control4
+
+//Tier 5 control5
+
+//Tier 6 control6
+
+//Tier 7 control7
+
+//Tier 8 control8
+
+//Tier 9 control9
+
+//Tier 10 control10
+
+//Tier 11 control11
+
+//////Probe Cores (probes#)
+
+//Tier 1 control1
+
+//Tier 2 probes2
+
+//Tier 3 probes3
+
+//Tier 4 probes4
+
+//Tier 5 probes5
+
+//Tier 6 probes6
+
+//Tier 7 probes7
+
+//Tier 8 probes8
+
+//Tier 9 probes9
+
+//Tier 10 probes10
+
+//Tier 11 probes11
+
+//////Landing (Landing Legs, Heat Shields, Parachutes)  (landing#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 landing9
+
+//Tier 10 landing10
+
+//Tier 11 landing11
+
+//////Reusability (Falcon 9/New Glenn/Starship Style Landing Legs, SMART Reuse, Booster Wings, etc)  (reuse#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 landing6
+
+//Tier 7 landing7
+
+//Tier 8 landing8
+
+//Tier 9 reuse9
+
+//Tier 10 reuse10
+
+//Tier 11 landing11
+
+//////Robotics (Breaking Ground Robotics, Rover Parts)  (robotics#)
+
+//Tier 1 control1
+
+//Tier 2 landing2
+
+//Tier 3 landing3
+
+//Tier 4 landing4
+
+//Tier 5 landing5
+
+//Tier 6 robotics6
+
+//Tier 7 robotics7
+
+//Tier 8 robotics8
+
+//Tier 9 robotics9
+
+//Tier 10 robotics10
+
+//Tier 11 probes11
+
+///////////////////////////
+/////Propulsion Branch/////
+///////////////////////////
+
+//////Solid Rocket Boosters  (solids#)
+
+//Tier 1 solids1
+
+//Tier 2 solids2
+
+//Tier 3 solids3
+
+//Tier 4 solids4
+
+//Tier 5 solids5
+
+//Tier 6 solids6
+
+//Tier 7 solids7
+
+//Tier 8 solids8
+
+//Tier 9 solids9
+
+//Tier 10 solids10
+
+//Tier 11 solids11
+
+//////Cryogenic Rocket Engines (LH2 and CH4 Engines)  (cryo#)
+
+//Tier 1 kerolox1
+
+//Tier 2 cryo2
+
+//Tier 3 cryo3
+
+//Tier 4 cryo4
+
+//Tier 5 cryo5
+
+//Tier 6 cryo6
+
+//Tier 7 cryo7
+
+//Tier 8 cryo8
+
+//Tier 9 cryo9
+
+//Tier 10 cryo10
+
+//Tier 11 cryo11
+
+//////Kerlox Rocket Engines (Liquid Fuel/RP-1 Engines, with a focus on Lifters)  (kerolox#)
+
+//Tier 1 kerolox1
+
+//Tier 2 kerolox2
+
+//Tier 3 kerolox3
+
+//Tier 4 kerolox4
+
+//Tier 5 kerolox5
+
+//Tier 6 kerolox6
+
+//Tier 7 kerolox7
+
+//Tier 8 kerolox8
+
+//Tier 9 kerolox9
+
+//Tier 10 kerolox10
+
+//Tier 11 kerolox11
+
+//Tier 12 kerolox12
+
+//////Hypergolic Rocket Engines (Upper Stage Engines (mainly those which really use hypergolics) - may use real hypergolics with Clamp-o-Tron's More Fuels)  (hypergol#)
+
+//Tier 1 kerolox1
+
+//Tier 2 hypergol2
+
+//Tier 3 hypergol3
+
+//Tier 4 hypergol4
+
+//Tier 5 hypergol5
+
+//Tier 6 hypergol6
+
+//Tier 7 hypergol7
+
+//Tier 8 hypergol8
+
+//Tier 9 hypergol9
+
+//Tier 10 hypergol10
+
+//Tier 11 hypergol11
+
+//////Conventional Fuel Tanks (tanks#)
+
+//Tier 1 kerolox1
+
+//Tier 2 tanks2
+
+//Tier 3 tanks3
+
+//Tier 4 tanks4
+
+//Tier 5 tanks5
+
+//Tier 6 tanks6
+
+//Tier 7 tanks7
+
+//Tier 8 tanks8
+
+//Tier 9 tanks9
+
+//Tier 10 tanks10
+
+//Tier 11 tanks11
+
+
+////////////////////////////////
+/////Nuclear/Exotics Branch/////
+////////////////////////////////
+
+//////Nuclear Rockets (Both Fission and Fusion) (ntr#)
+
+//Tier 8 reactors8
+
+//Tier 9 ntr9
+
+//Tier 10 ntr10
+
+//Tier 11 ntr11
+
+//Tier 12 ntr12
+
+//Tier 13 ntr13
+
+//Tier 14 ntr14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Nuclear Reactors (Both Fission and Fusion) (reactors#)
+
+//Tier 5 reactors5
+
+//Tier 6 reactors6
+
+//Tier 7 reactors7
+
+//Tier 8 reactors8
+
+//Tier 9 reactors9
+
+//Tier 10 reactors10
+
+//Tier 11 reactors11
+
+//Tier 12 reactors12
+
+//Tier 13 reactors13
+
+//Tier 14 reactors14
+
+//Tier 15 reactors15
+
+//Tier 16 reactors16
+
+//Faster Than Light (ftl#)
+
+//Tier 16 ftl16
+
+//Electromagnetic Propulsion (Xenon/Argon Thrusters) (ion#)
+
+//Tier 6 ion6
+
+//Tier 7 ion7
+
+//Tier 8 ion8
+
+//Tier 9 ion9
+
+//Tier 10 ion10
+
+//Tier 11 ion11
+
+//Exotic Propulsion (Plasma/Lithium/Antimatter) (plasma#)
+
+//Tier 10 plasma10
+
+//Tier 11 plasma11
+
+//Tier 12 plasma12
+
+//Tier 13 plasma13
+
+//Tier 14 plasma14
+
+//Tier 15 plasma15
+
+//Tier 16 plasma16
+
+
+//////////////////////////
+/////Electrics Branch/////
+//////////////////////////
+
+//////Electrics (Batteries, Capacitors, and Fuel Cells)  (electrics#)
+
+//Tier 1 electrics1
+
+//Tier 2 electrics2
+
+//Tier 3 electrics3
+
+//Tier 4 electrics4
+
+//Tier 5 electrics5
+
+//Tier 6 electrics6
+
+//Tier 7 electrics7
+
+//Tier 8 electrics8
+
+//Tier 9 electrics9
+
+//Tier 10 electrics10
+
+//Tier 11 electrics11
+
+//Tier 12 electrics12
+
+///// Solar Panels (and technically solar sails too) (solar#)
+
+//Tier 3 solar3
+
+//Tier 4 solar4
+
+//Tier 5 solar5
+
+//Tier 6 solar6
+
+//Tier 7 solar7
+
+//Tier 8 solar8
+
+//Tier 9 solar9
+
+//Tier 10 solar10
+
+//Tier 11 solar11
+
+//Tier 12 solar12
+
+//////Thermal - Radiators and Heat Management Systems  (thermal#)
+
+//Tier 5 thermal5
+
+//Tier 6 thermal6
+
+//Tier 7 thermal7
+
+//Tier 8 thermal8
+
+//Tier 9 thermal9
+
+//Tier 10 thermal10
+
+//Tier 11 thermal11
+
+//Tier 12 thermal12
+
+//////////////////////////////////////////////////////////////////
+/////Construction/Logistics/Science/Manned Spaceflight Branch/////
+//////////////////////////////////////////////////////////////////
+
+//////Construction (Adapters, Nosecones, Decouplers, Engine Plates/Mounts, Trusses, etc  (construction#)
+
+//Tier 1 construction1
+
+//Tier 2 construction2
+
+//Tier 3 construction3
+
+//Tier 4 construction4
+
+//Tier 5 construction5
+
+//Tier 6 construction6
+
+//Tier 7 construction7
+
+//Tier 8 construction8
+
+//Tier 9 construction9
+
+//Tier 10 construction10
+
+//Tier 11 construction11
+
+//Tier 12 construction12
+
+//////ISRU (Resource Miners and Converters) (isru#)
+
+//Tier 9 isru9
+
+//Tier 10 isru10
+
+//Tier 11 isru11
+
+//Tier 12 isru12
+
+//////Logistics and Life-Support (Resource Storage, Life-Support Modules, Containers, etc)  (logistics#)
+
+//Tier 6 logistics6
+@PART[TacAirFilter]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacCarbonExtractor]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacSabatierRecycler]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacWaterPurifier]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+@PART[TacWaterSplitter]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics6
+
+}
+
+//Tier 7 logistics7
+
+//Tier 8 logistics8
+@PART[TacCarbonExtractorLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[TacSabatierRecyclerLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+@PART[TacWaterPurifierLarge]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics8
+
+}
+
+//Tier 9 logistics9
+
+//Tier 10 logistics10
+@PART[TacCarbonExtractorLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics10
+
+}
+@PART[TacSabatierRecyclerLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics10
+
+}
+@PART[TacWaterPurifierLarge375]:AFTER[TacLifeSupport] //
+{
+	@TechRequired = logistics10
+
+}
+
+//Tier 11 logistics11
+
+//////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
+
+//Tier 5 capsules5
+
+//Tier 6 capsules6
+
+//Tier 7 capsules7
+
+//Tier 8 capsules8
+
+//Tier 9 capsules9
+
+//Tier 10 capsules10
+
+//Tier 11 capsules11
+
+//////Space Station Parts (Both Structural and Crewed)  (spaceStations#)
+
+//Tier 6 spaceStations6
+
+//Tier 7 spaceStations7
+
+//Tier 8 spaceStations8
+
+//Tier 9 spaceStations9
+
+//Tier 10 spaceStations10
+
+//Tier 11 spaceStations11
+
+
+//////Planetary Bases (Both structural and crewed) (bases#)
+
+//Tier 9 bases9
+
+//Tier 10 bases10
+
+//Tier 11 bases11
+
+//Tier 12 bases12
+
+//////Science Equipment, SCANSAT scanners (resource ones go in ISRU), and the like (Labs go in stations however) (science#)
+
+//Tier 1 construction1
+
+//Tier 2 science2
+
+//Tier 3 science3
+
+//Tier 4 science4
+
+//Tier 5 science5
+
+//Tier 6 science6
+
+//Tier 7 science7
+
+//Tier 8 science8
+
+//Tier 9 science9
+
+//Tier 10 science10
+
+//Tier 11 science11
+
+//Tier 12 science12


### PR DESCRIPTION
Adds config files for TAC LS cans & recyclers to the Logistics branch. Balance pass may be required. 2.5m cans & recyclers appear at the same time as Apollo service modules. Smaller and larger parts are earlier and later, respectively.