### PR TITLE
Random Procedural Parts/Fairings fixes

### DIFF
--- a/ModSupport/ProceduralParts/proceduralParts.cfg
+++ b/ModSupport/ProceduralParts/proceduralParts.cfg
@@ -796,10 +796,6 @@
 //Tier 10 logistics10
 
 //Tier 11 logistics11
-@PARTUPGRADE[ProceduralPartsTankUnlimited]:AFTER[ProceduralParts]
-{
-	@techRequired = logistics11
-}
 
 //////Manned Spacecraft, Command Modules (except landers), and Launch Escape Systems  (capsules#)
 


### PR DESCRIPTION
* Adds the stack separator option to Procedural Parts stack decouplers.
* Removes duplicated technode definition for the unlimited PP liquid tank (`logistics11` to `tank8`).