### PR TITLE
[Mod Support] Mars/Duna Direct

### DIFF
--- a/ModSupport/MarsDirect/MarsDirect.cfg
+++ b/ModSupport/MarsDirect/MarsDirect.cfg
@@ -1,0 +1,122 @@
+// Parts
+// have all mars direct stuff unlocked in the same tier
+// the proposal comes from 1990, to use shuttle-derived parts
+// place in tier 9
+// all engines (MD-Stage1Engines, MD-Stage2Engine, MD-HabEngines) use methalox like with the original proposal, go in cryo
+// habs and the stages go under bases
+// rcs uses hydrazine as usual
+
+// MD-HabLadder	    advExploration           => landing9
+// MD-Ladder	    advExploration           => landing9
+// MD-HabRCS	    advFlightControl         => control9
+// MD-Hab	        commandModules           => capsules9
+// MD-Sandbags	    commandModules           => bases9
+// MD-Stage2	    commandModules           => capsules9
+// MD-Greenhouse	experimentalAerodynamics => bases9
+// MD-Stage1	    experimentalAerodynamics => capsules9
+// MD-Heatshield-V2	heavyLanding             => landing9
+// MD-Heatshield	heavyLanding             => landing9
+// MD-Dockingport	landing                  => spaceStations9
+// MD-Nosecone	    landing                  => construction9
+// MD-Antenna	    precisionEngineering     => comms9
+// MD-HabAntenna	precisionEngineering     => comms9
+// MD-HabEngines	propulsionSystems        => cryo9
+// MD-Stage1Engines	propulsionSystems        => cryo9
+// MD-Stage2Engines	propulsionSystems        => cryo9
+// MD-HabLegs	    survivability            => landing9
+// MD-Legs          survivability            => landing9
+
+@PART[MD-Sandbags]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = bases9
+
+}
+@PART[MD-Greenhouse]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = bases9
+
+}
+@PART[MD-Hab]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = capsules9
+
+}
+@PART[MD-Stage2]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = capsules9
+
+}
+@PART[MD-Stage1]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = capsules9
+
+}
+@PART[MD-Antenna]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = comms9
+
+}
+@PART[MD-HabAntenna]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = comms9
+
+}
+@PART[MD-Nosecone]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = construction9
+
+}
+@PART[MD-HabRCS]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = control9
+
+}
+@PART[MD-HabEngines]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = cryo9
+
+}
+@PART[MD-Stage1Engines]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = cryo9
+
+}
+@PART[MD-Stage2Engines]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = cryo9
+
+}
+@PART[MD-HabLadder]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = landing9
+
+}
+@PART[MD-Ladder]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = landing9
+
+}
+@PART[MD-Heatshield-V2]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = landing9
+
+}
+@PART[MD-Heatshield]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = landing9
+
+}
+@PART[MD-HabLegs]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = landing9
+
+}
+@PART[MD-Legs]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = landing9
+
+}
+@PART[MD-Dockingport]:AFTER[WildBlueIndustries]
+{
+	@TechRequired = spaceStations9
+}

--- a/ModSupport/MarsDirect/MarsDirect.cfg
+++ b/ModSupport/MarsDirect/MarsDirect.cfg
@@ -26,97 +26,97 @@
 // MD-HabLegs	    survivability            => landing9
 // MD-Legs          survivability            => landing9
 
-@PART[MD-Sandbags]:AFTER[WildBlueIndustries]
+@PART[MD-Sandbags]:AFTER[MarsDirect]
 {
 	@TechRequired = bases9
 
 }
-@PART[MD-Greenhouse]:AFTER[WildBlueIndustries]
+@PART[MD-Greenhouse]:AFTER[MarsDirect]
 {
 	@TechRequired = bases9
 
 }
-@PART[MD-Hab]:AFTER[WildBlueIndustries]
+@PART[MD-Hab]:AFTER[MarsDirect]
 {
 	@TechRequired = capsules9
 
 }
-@PART[MD-Stage2]:AFTER[WildBlueIndustries]
+@PART[MD-Stage2]:AFTER[MarsDirect]
 {
 	@TechRequired = capsules9
 
 }
-@PART[MD-Stage1]:AFTER[WildBlueIndustries]
+@PART[MD-Stage1]:AFTER[MarsDirect]
 {
 	@TechRequired = capsules9
 
 }
-@PART[MD-Antenna]:AFTER[WildBlueIndustries]
+@PART[MD-Antenna]:AFTER[MarsDirect]
 {
 	@TechRequired = comms9
 
 }
-@PART[MD-HabAntenna]:AFTER[WildBlueIndustries]
+@PART[MD-HabAntenna]:AFTER[MarsDirect]
 {
 	@TechRequired = comms9
 
 }
-@PART[MD-Nosecone]:AFTER[WildBlueIndustries]
+@PART[MD-Nosecone]:AFTER[MarsDirect]
 {
 	@TechRequired = construction9
 
 }
-@PART[MD-HabRCS]:AFTER[WildBlueIndustries]
+@PART[MD-HabRCS]:AFTER[MarsDirect]
 {
 	@TechRequired = control9
 
 }
-@PART[MD-HabEngines]:AFTER[WildBlueIndustries]
+@PART[MD-HabEngines]:AFTER[MarsDirect]
 {
 	@TechRequired = cryo9
 
 }
-@PART[MD-Stage1Engines]:AFTER[WildBlueIndustries]
+@PART[MD-Stage1Engines]:AFTER[MarsDirect]
 {
 	@TechRequired = cryo9
 
 }
-@PART[MD-Stage2Engines]:AFTER[WildBlueIndustries]
+@PART[MD-Stage2Engines]:AFTER[MarsDirect]
 {
 	@TechRequired = cryo9
 
 }
-@PART[MD-HabLadder]:AFTER[WildBlueIndustries]
+@PART[MD-HabLadder]:AFTER[MarsDirect]
 {
 	@TechRequired = landing9
 
 }
-@PART[MD-Ladder]:AFTER[WildBlueIndustries]
+@PART[MD-Ladder]:AFTER[MarsDirect]
 {
 	@TechRequired = landing9
 
 }
-@PART[MD-Heatshield-V2]:AFTER[WildBlueIndustries]
+@PART[MD-Heatshield-V2]:AFTER[MarsDirect]
 {
 	@TechRequired = landing9
 
 }
-@PART[MD-Heatshield]:AFTER[WildBlueIndustries]
+@PART[MD-Heatshield]:AFTER[MarsDirect]
 {
 	@TechRequired = landing9
 
 }
-@PART[MD-HabLegs]:AFTER[WildBlueIndustries]
+@PART[MD-HabLegs]:AFTER[MarsDirect]
 {
 	@TechRequired = landing9
 
 }
-@PART[MD-Legs]:AFTER[WildBlueIndustries]
+@PART[MD-Legs]:AFTER[MarsDirect]
 {
 	@TechRequired = landing9
 
 }
-@PART[MD-Dockingport]:AFTER[WildBlueIndustries]
+@PART[MD-Dockingport]:AFTER[MarsDirect]
 {
 	@TechRequired = spaceStations9
 }

--- a/ModSupport/MarsDirect/MarsDirectMetholoxEngines.cfg
+++ b/ModSupport/MarsDirect/MarsDirectMetholoxEngines.cfg
@@ -1,0 +1,34 @@
+// converts the engines in the Mars/Duna Direct mod to use metholox
+// the tanks don't need patching because of the tank switch
+
+// looking at other mods that use metholox (cryoengines, hephaistos/ula vulcan), they use 3:1 methane:lox
+
+// MD-HabEngines
+// MD-Stage1Engines
+// MD-Stage2Engines
+@PART[MD-HabEngines,MD-Stage1Engines,MD-Stage2Engines]:NEEDS[MarsDirect]:AFTER[zzzSkyhawkScienceSystem]
+{
+    @MODULE[ModuleEnginesFX]
+    {
+        // remove old propellants
+        !PROPELLANT[*] {}
+		!PROPELLANT[*] {}
+
+        // add in the new ones
+        PROPELLANT
+		{
+			name = LqdMethane
+			ratio = 3
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Oxidizer
+			ratio = 1
+		}
+        // keep everything else the same
+    }
+}
+
+
+

--- a/ModSupport/WildBlueIndustries/WildBlueIndustries.cfg
+++ b/ModSupport/WildBlueIndustries/WildBlueIndustries.cfg
@@ -1,16 +1,16 @@
 //Tiers
-Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
-Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
-Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1_25m parts
-Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1_5m parts
-Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1_875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
-Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2_5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
-Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3_125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
-Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3_75m parts - probes include Voyager and RoveMate gear
-Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
-Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
-Tier 10 - Near Future Rocketry - Advanced game changer rockets - Starship/BFS, New Glenn, etc - 7_5m parts - near future probe missions like Europa Clipper
-Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
+// Tier 0 - Starting Gear - basic low atmospheric sounding rockets - may be merged with tier 1
+// Tier 1 - Sounding Rockets - Capable of reaching space, along with the first introduction of Kerolox
+// Tier 2 - Early Orbital Rockets - think Sputnik, Vangaurd, Scout, and Redstone/Explorer 1 - probes like Sputnik and Explorer 1 - 1_25m parts
+// Tier 3 - Improved Orbital Rockets - think Thor, Juno II, Agena A, etc - basic orbital research and comms sats - 1_5m parts
+// Tier 4 - Mature Orbital Rockets - Advanced Thor, Agena B, Delta E and F, and early 1_875 rockets like Atlas and Agena - probes focus on the Ranger missions to the Moon/Mun&Minmus
+// Tier 5 - High-Performance Rockets - Atlas, Titan II, Centaur, Delta II, Agena D, Mercury - 2_5 parts introduction - probes including Mariner and Verena, and the Surveyor Moon landers
+// Tier 6 - Medium-Lift Rockets - Delta III, Titan III, LDC, Atlas CELV, Gemini, First Space Stations - 3_125m parts - probes include more advanced mariners, pioneer 10/11, the first atmospheric landers (Viking anyone?) and many orbiters
+// Tier 7 - Heavy-Lift Rockets - Saturn I/C, Delta IV, Atlas V, Titan IV, Big G, MOL Agena SOT - 3_75m parts - probes include Voyager and RoveMate gear
+// Tier 8 - Super Heavy-Lift Rockets - Saturn V, Space Shuttle, Apollo LEM, Skylab - 5m parts - probes like Cassini and other advanced probes
+// Tier 9 - Modern Rockets - Advanced Saturn Variants, Apollo Blks 3-5, VFB, Falcon 9/Heavy, Space Launch System, Vulcan, Ares I/V, Orion, Starliner, Crew/Cargo Dragon, Cygnus - modern probe missions like Juno and New Horizons
+// Tier 10 - Near Future Rocketry - Advanced game changer rockets - Starship/BFS, New Glenn, etc - 7_5m parts - near future probe missions like Europa Clipper
+// Tier 11 - Far Future Rocketry - Futuristic Prototypes and upgrades of previous parts - also SpaceY 10m tankage - AI?
 
 //Blueshift Support
 @PART[*]:HAS[#TechRequired[wbiWarpTech]]:AFTER[WildBlueIndustries] //


### PR DESCRIPTION
Support for the [Duna Direct](https://forum.kerbalspaceprogram.com/index.php?/topic/179544-1101-duna-direct/) mod.

I've placed the parts in tier 9 for the following two reasons:

* The original Mars Direct proposal is from 1990, way post-Apollo.
* The proposal calls for a Shuttle-derived rocket, similar to SLS.

~~Currently the engines use kerolox, when I figure it out they'll use metholox instead.~~