### PR TITLE
Add support for bluedog_Beacon1

### DIFF
--- a/ModSupport/Bluedog_DB/Bluedog_DB.cfg
+++ b/ModSupport/Bluedog_DB/Bluedog_DB.cfg
@@ -1216,6 +1216,11 @@
 //Tier 1 control1
 
 //Tier 2 probes2
+@PART[bluedog_Beacon1]:AFTER[Bluedog_DB] //
+{
+	@TechRequired = probes2
+
+}
 @PART[bluedog_Explorer_11]:AFTER[Bluedog_DB] //
 {
 	@TechRequired = probes2


### PR DESCRIPTION
Nothing much, just support for the 'Pathfinder-BCN "Bloon" Satellite' from the current BDB release. The catch-all made it show up at start, I've put it to probes2 alongside the other early sats where I think it belongs.