### PR TITLE
Fix "Basic Weather Imaging" experiment for the bluedog_TIROS early weather satellite with SkyhawkKerbalism

### DIFF
--- a/Patches/Science/ScienceExperiments.cfg
+++ b/Patches/Science/ScienceExperiments.cfg
@@ -405,7 +405,7 @@ EXPERIMENT_DEFINITION:NEEDS[!FeatureScience]
 }
 
 //Basic Weather Imaging
-EXPERIMENT_DEFINITION:NEEDS[!FeatureScience]
+EXPERIMENT_DEFINITION
 {
 	id = sss_basicWeatherImaging
 	title = Basic Weather Imagery


### PR DESCRIPTION
SkyhawkKerbalism defines a Kerbalism experiment with id "sss_basicWeatherImaging" for the bluedog_TIROS satellite, but the corresponding EXPERIMENT_DEFINITION here has a `NEEDS[!FeatureScience]`. Fixed it by removing the `NEEDS[!FeatureScience]`.