### PR TITLE
Real Antenna mod compatibility patches

### DIFF
--- a/ModSupport/RealAntenna/RA_bandinfo.cfg
+++ b/ModSupport/RealAntenna/RA_bandinfo.cfg
@@ -1,0 +1,77 @@
+@RealAntennasCommNetParams:AFTER[RealAntennas]:NEEDS[!RealismOverhaul]
+{
+    %minRelayTL = 3
+    @TargetingMode[Vessel] { %techLevel = 2 }
+    @TargetingMode[BodyCenter] { %techLevel = 0 }
+    @TargetingMode[BodyLatLonAlt] { %techLevel = 4 }
+    @TargetingMode[AzEl] { %techLevel = 0 }
+    @TargetingMode[OrbitRelative] { %techLevel = 2 }
+
+    !BandInfo,* {}
+    BandInfo
+    {
+        name = VHF
+        TechLevel = 0
+        Frequency = 150e6
+        ChannelWidth = 12.5e3
+    }
+    BandInfo
+    {
+        name = UHF
+        TechLevel = 3
+        Frequency = 430e6
+        ChannelWidth = 31.5e3
+    }
+    BandInfo
+    {
+        name = S
+        TechLevel = 4
+        Frequency = 2.29e9
+        ChannelWidth = 0.330e6
+    }
+    BandInfo
+    {
+        name = X
+        TechLevel = 5
+        Frequency = 8.45e9
+        ChannelWidth = 1.36e6
+    }
+    BandInfo
+    {
+        name = Ku
+        TechLevel = 6
+        Frequency = 12.75e9
+        ChannelWidth = 8.192e6
+    }
+    BandInfo
+    {
+        name = Ka
+        TechLevel = 7
+        Frequency = 32.235e9
+        ChannelWidth = 20e6
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleRealAntenna]]:AFTER[zRealAntennas]:NEEDS[!RealismOverhaul]
+{
+    @MODULE[ModuleRealAntenna]:HAS[#antennaDiameter[*],#RFBand[L]],*
+    {
+        %RFBand = S
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleRealAntenna]]:AFTER[zRealAntennas]:NEEDS[!RealismOverhaul]
+{
+    @MODULE[ModuleRealAntenna]:HAS[#RFBand[L]],*
+    {
+        %RFBand = UHF
+    }
+}
+
+@PART[*]:HAS[@MODULE[ModuleCommand],@MODULE[ModuleRealAntenna]]:AFTER[zRealAntennas]:NEEDS[!RealismOverhaul]
+{
+    @MODULE[ModuleRealAntenna]
+    {
+        %RFBand = UHF
+    }
+}

--- a/ModSupport/RealAntenna/RA_encoderinfo.cfg
+++ b/ModSupport/RealAntenna/RA_encoderinfo.cfg
@@ -1,0 +1,54 @@
+@RealAntennasCommNetParams:AFTER[RealAntennas]
+{
+    !EncoderInfo,* {}
+    EncoderInfo
+    {
+        name = Analog FSK
+        TechLevel = 0
+        CodingRate = 0.001
+        RequiredEbN0 = 10
+    }
+    EncoderInfo
+    {
+        name = None
+        TechLevel = 2
+        CodingRate = 1
+        RequiredEbN0 = 10
+    }
+    EncoderInfo
+    {
+        name = Reed-Muller 1,3
+        TechLevel = 3
+        CodingRate = 0.5
+        RequiredEbN0 = 6.5
+    }
+    EncoderInfo
+    {
+        name = Reed-Solomon 255/223
+        TechLevel = 5
+        CodingRate = 0.8745
+        RequiredEbN0 = 6.1
+    }
+    EncoderInfo
+    {
+        name = Convolutional 7, 1/2
+        TechLevel = 6
+        CodingRate = 0.5
+        RequiredEbN0 = 4.5
+    }
+    EncoderInfo
+    {
+        name = Concatenated Reed-Solomon,Convolutional
+        reference = http://www.ieee802.org/16/tg1/phy/contrib/802161pc-00_33.pdf
+        TechLevel = 7
+        CodingRate = 0.43725
+        RequiredEbN0 = 3.3
+    }
+    EncoderInfo
+    {
+        name = Turbo 1/2
+        TechLevel = 8
+        CodingRate = 0.5
+        RequiredEbN0 = 1
+    }
+}

--- a/ModSupport/RealAntenna/RA_techupgrades.cfg
+++ b/ModSupport/RealAntenna/RA_techupgrades.cfg
@@ -1,0 +1,227 @@
+@RealAntennasCommNetParams:NEEDS[!RealismOverhaul]:AFTER[RealAntennas]
+{
+    !TechLevelInfo,* {}
+    TechLevelInfo
+    {
+        name = TL0
+        Level = 0
+        Description = WW2-era
+        PowerEfficiency = 0.0555
+        ReflectorEfficiency = 0.5
+        MinDataRate = 4
+        MaxDataRate = 4
+        MaxPower = 20
+        MassPerWatt = 1.6
+        BaseMass = 1
+        BasePower = 2
+        BaseCost = 2
+        CostPerWatt = 5
+        ReceiverNoiseTemperature = 27000	// 20dB
+    }
+    TechLevelInfo
+    {
+        name = TL1
+        Level = 1
+        Description = Lunar Range Comms, 1956: 26m antenna 1958
+        PowerEfficiency = 0.0769
+        ReflectorEfficiency = 0.52
+        MinDataRate = 4
+        MaxDataRate = 4
+        MaxPower = 30
+        MassPerWatt = 1.34
+        BaseMass = 0.26
+        BasePower = 0.3
+        BaseCost = 4
+        CostPerWatt = 4
+        ReceiverNoiseTemperature = 11500	// 16dB
+    }
+    TechLevelInfo
+    {
+        name = TL2
+        Level = 2
+        Description = Digital Comms, 1959-1960
+        PowerEfficiency = 0.1
+        ReflectorEfficiency = 0.54
+        MinDataRate = 1
+        MaxDataRate = 64
+        MaxPower = 37
+        MassPerWatt = 1.16
+        BaseMass = 6.9
+        BasePower = 8
+        BaseCost = 30
+        CostPerWatt = 3.5
+        ReceiverNoiseTemperature = 7000	// 14dB
+    }
+    TechLevelInfo
+    {
+        name = TL3
+        Level = 3
+        Description = Interplanetary Comms, 1961-1963: Maser 1962, S/C noise reduction 1961 (300-3000K=10dB noise temp)
+        PowerEfficiency = 0.1304
+        ReflectorEfficiency = 0.56
+        MinDataRate = 8
+        MaxDataRate = 64
+        MaxPower = 37
+        MassPerWatt = 1
+        BaseMass = 20.2
+        BasePower = 19.5
+        BaseCost = 50
+        CostPerWatt = 3
+        ReceiverNoiseTemperature = 5800	// 13dB
+    }
+    TechLevelInfo
+    {
+        name = TL4
+        Level = 4
+        Description = Improved Comms, 1964-1966: 64m Antenna 1967
+        PowerEfficiency = 0.1667
+        ReflectorEfficiency = 0.58
+        MinDataRate = 8
+        MaxDataRate = 4096
+        MaxPower = 40
+        MassPerWatt = 0.86
+        BaseMass = 17.2
+        BasePower = 25.7
+        BaseCost = 80
+        CostPerWatt = 2.5
+        ReceiverNoiseTemperature = 4500	// 11.7dB
+    }
+    TechLevelInfo
+    {
+        name = TL5
+        Level = 5
+        Description = Advanced Comms, 1967-1971: Noise reduction 1968, block coding 1969
+        PowerEfficiency = 0.2222
+        ReflectorEfficiency = 0.6
+        MinDataRate = 16
+        MaxDataRate = 16384
+        MaxPower = 43
+        MassPerWatt = 0.75
+        BaseMass = 21
+        BasePower = 23
+        BaseCost = 120
+        CostPerWatt = 2
+        ReceiverNoiseTemperature = 3000	// 10dB		https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660015650.pdf
+    }
+    TechLevelInfo
+    {
+        name = TL6
+        Level = 6
+        Description = Deep Space Comms, 1971-1974: Antenna improvements 1971-1972, Convolutional coding ~1973
+        PowerEfficiency = 0.25
+        ReflectorEfficiency = 0.62
+        MinDataRate = 16
+        MaxDataRate = 131072
+        MaxPower = 43
+        MassPerWatt = 0.6444
+        BaseMass = 30.7
+        BasePower = 21.4
+        BaseCost = 175
+        CostPerWatt = 1.7
+        ReceiverNoiseTemperature = 1540	// 7.5dB
+    }
+    TechLevelInfo
+    {
+        name = TL7
+        Level = 7
+        Description = High Data Rate Comms, 1976-1980: X-Band ~1975, concatenated coding, MW noise reduction ~1980
+        PowerEfficiency = 0.3
+        ReflectorEfficiency = 0.64
+        MinDataRate = 16
+        MaxDataRate = 262144
+        MaxPower = 46
+        MassPerWatt = 0.6
+        BaseMass = 21.3
+        BasePower = 18.3
+        BaseCost = 125
+        CostPerWatt = 1.2
+        ReceiverNoiseTemperature = 1100	// 6.1dB  https://commons.erau.edu/cgi/viewcontent.cgi?referer=https://www.google.com/&httpsredir=1&article=2697&context=space-congress-proceedings
+    }
+    TechLevelInfo
+    {
+        name = TL8
+        Level = 8
+        Description = Massive Scale Comms, 1986-1997: 70m antennas 1988
+        PowerEfficiency = 0.3724
+        ReflectorEfficiency = 0.66
+        MinDataRate = 16
+        MaxDataRate = 262144
+        MaxPower = 46
+        MassPerWatt = 0.54
+        BaseMass = 21.3
+        BasePower = 18.3
+        BaseCost = 75
+        CostPerWatt = 0.5
+        ReceiverNoiseTemperature = 500	// 2.6dB
+    }
+    TechLevelInfo
+    {
+        name = TL9
+        Level = 9
+        Description = Efficient Comms, 1998-2008: Super-cooled maser & feed 1995, Ka-band 2004
+        PowerEfficiency = 0.4397
+        ReflectorEfficiency = 0.68
+        MinDataRate = 16
+        MaxDataRate = 134217728
+        MaxPower = 50
+        MassPerWatt = 0.1418
+        BaseMass = 7.5
+        BasePower = 11.7
+        BaseCost = 50
+        CostPerWatt = 0.4
+        ReceiverNoiseTemperature = 200	// 1.8dB
+    }
+}
+
+@PARTUPGRADE[commsTL1]:AFTER[RealAntennas]
+{
+	%level = 1
+	%techRequired = comms2
+}
+@PARTUPGRADE[commsTL2]:AFTER[RealAntennas]
+{
+	%level = 2
+	%techRequired = comms3
+}
+@PARTUPGRADE[commsTL3]:AFTER[RealAntennas]
+{
+	%level = 3
+	%techRequired = comms4
+}
+@PARTUPGRADE[commsTL4]:AFTER[RealAntennas]
+{
+	%level = 4
+	%techRequired = comms5
+}
+@PARTUPGRADE[commsTL5]:AFTER[RealAntennas]
+{
+	%level = 5
+	%techRequired = comms6
+}
+@PARTUPGRADE[commsTL6]:AFTER[RealAntennas]
+{
+	%level = 6
+	%techRequired = comms7
+}
+@PARTUPGRADE[commsTL7]:AFTER[RealAntennas]
+{
+	%level = 7
+	%techRequired = comms8
+}
+@PARTUPGRADE[commsTL8]:AFTER[RealAntennas]
+{
+	%level = 8
+	%techRequired = comms9
+}
+@PARTUPGRADE[commsTL9]:AFTER[RealAntennas]
+{
+	%level = 9
+	%techRequired = comms10
+}
+@PARTUPGRADE[commsTL*]:AFTER[RealAntennas]
+{
+	%title = #Comms Tech Level $level$
+	%description = #Upgrades Comms to Tech Level $level$
+	%partIcon = RelayAntenna50
+	!level = DEL
+}


### PR DESCRIPTION
Some patches to enable RealAntenna compatibility. The biggest change needed to be the tech upgrades to properly place the RA upgrades in the SSS tree. The upgrade levels align almost perfectly with SSS. This is what I'm using in my current career save with good results. Borrowed some data from Realism Overhaul for additional realism.