### PR TITLE
Fix version file URL property

### DIFF
--- a/Versioning/SkyhawkScienceSystem.version
+++ b/Versioning/SkyhawkScienceSystem.version
@@ -1,6 +1,6 @@
 {
     "NAME":"SkyhawkScienceSystem",
-    "URL":"https://github.com/CessnaSkyhawk/SkyhawkScienceSystem",
+    "URL":"https://github.com/CessnaSkyhawk/SkyhawkScienceSystem/raw/main/Versioning/SkyhawkScienceSystem.version",
     "DOWNLOAD":"",
     "VERSION":
     {


### PR DESCRIPTION
Hi @CessnaSkyhawk!

The version file's URL property is supposed to point to a "remote version file", an online copy of the version file that you can update to affect the mod's compatibility after release (or notify users of available updates if they have KSP-AVC installed). Currently it points to the repo; this pull request fixes it.

Noticed while working on KSP-CKAN/NetKAN#9379.

Cheers!
