### PR TITLE
Fix some SAS upgrade related B9PartSwitch warnings with BDB 11.0

### DIFF
--- a/ModSupport/Bluedog_DB/Apollo_CrewPod.cfg
+++ b/ModSupport/Bluedog_DB/Apollo_CrewPod.cfg
@@ -1,0 +1,12 @@
+// Specific support for bluedog_Apollo_CrewPod and bluedog_Apollo_CrewPod_5crew
+
+@PART[bluedog_Apollo_CrewPod*]:AFTER[Bluedog_DB] {
+  // Apollo pods can optionally be used uncrewed after unlocking the bluedog_SAS1 (prograde/retrograde) upgrade.
+  // Tie this to the sss_SAS2 upgrade (all orbit relative orientations) instead, as SSS does not have
+  // a dedicated prograde/retrograde unlock.
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[Probecore]] {
+     @SUBTYPE[Uncrewed] {
+         @upgradeRequired = sss_SAS2
+     }
+  }
+}

--- a/Patches/Control/SASUpgrades.cfg
+++ b/Patches/Control/SASUpgrades.cfg
@@ -36,6 +36,43 @@
 		
 	}
 }
+@PART[*]:HAS[!MODULE[ModuleCommand]]:FOR[zzzSkyhawkScienceSystem]
+{
+	!MODULE[ModuleSAS] {} // Remove original SAS Module
+	MODULE
+	{
+		name = ModuleSAS
+		SASServiceLevel = 0
+		moduleIsEnabled = false
+		
+		showUpgradesInModuleInfo = false
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = sss_SAS1
+				techRequired__ = control3
+				SASServiceLevel = 0
+				moduleIsEnabled = true
+			}
+			UPGRADE
+			{
+				name__ = sss_SAS2
+				techRequired__ = control5							
+				SASServiceLevel = 2
+				moduleIsEnabled = true
+			}
+			UPGRADE
+			{
+				name__ = sss-SAS3
+				techRequired__ = control7							
+				SASServiceLevel = 3
+				moduleIsEnabled = true
+			}
+		}
+		
+	}
+}
 PARTUPGRADE
 {
 	type = sas


### PR DESCRIPTION
BDB 11.0 now apparently has ModuleSAS on some parts that do not have a ModuleCommand at all, and so are not caught by the generic SAS upgrade patch. Fixed generically in afdff3e by appliying the same logik to parts with ModuleSAS but no ModuleCommand as for the uncrewed probes with ModuleCommand and ModuleSAS.

Also, BDB11 adds an option to fly Kane-11 (Apollo) uncrewed, gated behind the BDB SAS upgrade that grants prograde/retrograde control. Fixed in b7b2f85 by tying that to the `sss_SAS2` upgrade instead.