### PR TITLE
Updated and improved support for Mk-33

### DIFF
--- a/ModSupport/WildBlueIndustries/Mk33_SSS.cfg
+++ b/ModSupport/WildBlueIndustries/Mk33_SSS.cfg
@@ -1,0 +1,89 @@
+@PART[Mk33*]:HAS[@MODULE[ModuleRCSFX]]:NEEDS[WildBlueIndustries]
+{
+	@MODULE[ModuleRCSFX]
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 455
+			key = 1 84
+			key = 1.6 0.01 0 0
+		}
+	}
+}
+
+@PART[KR2200L]:NEEDS[WildBlueIndustries]
+{
+	@MODULE[ModuleEnginesFX],0
+	{
+		@maxThrust = 1400
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 455
+			key = 1 415
+			key = 4 290
+			key = 20 0.01
+		}
+	}
+	@MODULE[ModuleEnginesFX],1
+	{
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 468
+			key = 1 420
+			key = 4 290
+			key = 20 0.01
+		}
+	}
+}
+
+@PART[mk33Launchpad]:NEEDS[WildBlueIndustries]
+{
+	MODULE:NEEDS[WildBlueTools]
+	{
+		name = WBIResourceDistributor
+	}
+
+	RESOURCE
+	{
+		name = LqdHydrogen
+		amount = 0
+		maxAmount = 400000
+	}
+
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 0
+		maxAmount = 61000
+	}
+}

--- a/ModSupport/WildBlueIndustries/WildBlueIndustries.cfg
+++ b/ModSupport/WildBlueIndustries/WildBlueIndustries.cfg
@@ -81,107 +81,108 @@
 
 //Tier 9 aerodynamics9
 
-//Tier 10 aerodynamics10
 @PART[Mk33BodyFlap]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33InnerElevon]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33NoseCone]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
-
+	@TechRequired = aerodynamics9
+	
 }
 @PART[Mk33OuterElevon]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33Tailfin]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33Wing]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33Cockpit]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33ProbeCore]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33DockingNoseCone]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[mk33AeroCone]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[mk33EngineCoupler]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[mk33EngineCoupler2]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[mk33EngineCoupler4]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33AftTank]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33FwdTank]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[Mk33MidTank]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[wbiMk33CargoModule]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[wbiMk33KrewModule]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[wbiMk33FuelModule]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
 @PART[wbiMk33CargoBay]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = aerodynamics10
+	@TechRequired = aerodynamics9
 
 }
+
+//Tier 10 aerodynamics10
 
 //Tier 11 aerodynamics11
 
@@ -249,13 +250,13 @@
 //Tier 8 control8
 
 //Tier 9 control9
-
-//Tier 10 control10
 @PART[wbiMk33RCSPod]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = control10
+	@TechRequired = control9
 
 }
+
+//Tier 10 control10
 
 //Tier 11 control11
 
@@ -302,23 +303,23 @@
 //Tier 8 landing8
 
 //Tier 9 landing9
-
-//Tier 10 landing10
 @PART[wbiMk33MainGear]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = landing10
+	@TechRequired = landing9
 
 }
 @PART[wbiMk33NoseGear]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = landing10
+	@TechRequired = landing9
 
 }
 @PART[wbiPostWheel]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = landing10
+	@TechRequired = landing9
 
 }
+
+//Tier 10 landing10
 
 //Tier 11 landing11
 
@@ -425,6 +426,11 @@
 //Tier 8 cryo8
 
 //Tier 9 cryo9
+@PART[KR2200L]:AFTER[WildBlueIndustries] //
+{
+	@TechRequired = cryo9
+
+}
 
 //Tier 10 cryo10
 
@@ -451,11 +457,6 @@
 //Tier 9 kerolox9
 
 //Tier 10 kerolox10
-@PART[KR2200L]:AFTER[WildBlueIndustries] //
-{
-	@TechRequired = kerolox10
-
-}
 
 //Tier 11 kerolox11
 
@@ -684,58 +685,58 @@
 //Tier 8 construction8
 
 //Tier 9 construction9
-
-//Tier 10 construction10
 @PART[wbiControlCab]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33CrewTowerBase]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33CrewTowerCockpitSection]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33CrewTowerMidSection]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33DockingPiston]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33LaunchPlatform]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
-
+	@TechRequired = construction9
+	
 }
 @PART[mk33PayloadCrane]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33PlatformElevator]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[mk33Strongback]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
 @PART[wbiMk33Airlock]:AFTER[WildBlueIndustries] //
 {
-	@TechRequired = construction10
+	@TechRequired = construction9
 
 }
+
+//Tier 10 construction10
 
 //Tier 11 construction11
 


### PR DESCRIPTION
changes :
-Mk-33 parts now are tier 9 parts (previously 10) for realism (reversable if balance breaking)
-KLR-2200 is now hydrolox fueled using WBI's CRP patch modified to SSS' needs
-Fuel Cell is disabled and replaced by SSS Kerbalism